### PR TITLE
Revalidate GitHub star count every 10 minutes

### DIFF
--- a/lib/github.ts
+++ b/lib/github.ts
@@ -11,7 +11,7 @@ export function formatStarCount(count: number) {
   }).format(count)
 }
 
-/** Cached star count for the docs header. Revalidates hourly. */
+/** Cached star count for the docs header. Revalidates every minute. */
 export async function getGithubStars(): Promise<number | null> {
   try {
     const res = await fetch(`https://api.github.com/repos/${REPO}`, {
@@ -19,7 +19,7 @@ export async function getGithubStars(): Promise<number | null> {
         Accept: "application/vnd.github+json",
         "User-Agent": "23rd.dev",
       },
-      next: { revalidate: 3600 },
+      next: { revalidate: 60 },
     })
     if (!res.ok) return null
     const data = (await res.json()) as { stargazers_count?: number }

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -11,7 +11,7 @@ export function formatStarCount(count: number) {
   }).format(count)
 }
 
-/** Cached star count for the docs header. Revalidates every minute. */
+/** Cached star count for the docs header. Revalidates every 10 minutes. */
 export async function getGithubStars(): Promise<number | null> {
   try {
     const res = await fetch(`https://api.github.com/repos/${REPO}`, {
@@ -19,7 +19,7 @@ export async function getGithubStars(): Promise<number | null> {
         Accept: "application/vnd.github+json",
         "User-Agent": "23rd.dev",
       },
-      next: { revalidate: 60 },
+      next: { revalidate: 600 },
     })
     if (!res.ok) return null
     const data = (await res.json()) as { stargazers_count?: number }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Drops the docs-header star count cache from 1 hour to 10 minutes so the badge stays closer to the live GitHub number without sitting on the unauthenticated API rate limit.

`getGithubStars()` still uses the GitHub REST API with Next.js `fetch` caching — only `revalidate` changed from `3600` → `600`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-64dd966a-67d4-49b0-a0bb-a22e75b889d5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-64dd966a-67d4-49b0-a0bb-a22e75b889d5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

