### PR TITLE
Add Back and Next buttons to docs MDX pages

### DIFF
--- a/app/docs/[[...slug]]/page.tsx
+++ b/app/docs/[[...slug]]/page.tsx
@@ -2,6 +2,7 @@ import { createRelativeLink } from "fumadocs-ui/mdx"
 import type { Metadata } from "next"
 import { notFound } from "next/navigation"
 
+import { DocsPager } from "@/components/docs-pager"
 import { DocsToc } from "@/components/docs-toc"
 import { getMDXComponents } from "@/components/mdx"
 import { source } from "@/lib/source"
@@ -38,6 +39,7 @@ export default async function Page(props: {
             })}
           />
         </div>
+        <DocsPager tree={source.getPageTree()} url={page.url} />
       </article>
       <DocsToc items={page.data.toc} />
     </div>

--- a/components/docs-pager.tsx
+++ b/components/docs-pager.tsx
@@ -1,0 +1,76 @@
+import { findNeighbour } from "fumadocs-core/page-tree"
+import type { Item, Root } from "fumadocs-core/page-tree"
+import { RiArrowLeftLine, RiArrowRightLine } from "@remixicon/react"
+import Link from "next/link"
+
+import { cn } from "@/lib/utils"
+
+function pageName(item: Item): string {
+  if (item.name == null) return "Page"
+  if (typeof item.name === "string") return item.name
+  if (typeof item.name === "number") return String(item.name)
+  return "Page"
+}
+
+function PagerLink({
+  item,
+  direction,
+}: {
+  item: Item
+  direction: "previous" | "next"
+}) {
+  const isPrevious = direction === "previous"
+
+  return (
+    <Link
+      href={item.url}
+      className={cn(
+        "group flex min-w-0 flex-1 flex-col gap-1 rounded-2xl border border-border bg-background px-4 py-3 transition-colors",
+        "hover:bg-muted hover:text-foreground",
+        "focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/30 focus-visible:outline-none",
+        isPrevious ? "items-start" : "items-end text-end"
+      )}
+    >
+      <span className="flex items-center gap-1 text-xs font-medium text-muted-foreground">
+        {isPrevious ? (
+          <>
+            <RiArrowLeftLine className="size-3.5 transition-transform group-hover:-translate-x-0.5" />
+            Back
+          </>
+        ) : (
+          <>
+            Next
+            <RiArrowRightLine className="size-3.5 transition-transform group-hover:translate-x-0.5" />
+          </>
+        )}
+      </span>
+      <span className="w-full truncate text-sm font-medium">{pageName(item)}</span>
+    </Link>
+  )
+}
+
+export function DocsPager({
+  tree,
+  url,
+}: {
+  tree: Root
+  url: string
+}) {
+  const { previous, next } = findNeighbour(tree, url, { separateRoot: false })
+
+  if (!previous && !next) return null
+
+  return (
+    <nav
+      aria-label="Docs pagination"
+      className="mt-12 flex flex-col gap-3 border-t border-border pt-8 sm:flex-row"
+    >
+      {previous ? (
+        <PagerLink item={previous} direction="previous" />
+      ) : (
+        <div className="hidden min-w-0 flex-1 sm:block" />
+      )}
+      {next ? <PagerLink item={next} direction="next" /> : null}
+    </nav>
+  )
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Adds a `DocsPager` under each docs article with **Back** and **Next** links.
- Neighbors come from the Fumadocs page tree (`findNeighbour` with `separateRoot: false`), so pagination follows the same order as the sidebar across sections.

## Test plan
- [x] Open `/docs` — only **Next** shows (first page)
- [x] Open a middle page (e.g. Getting Started) — both **Back** and **Next** show with correct titles
- [x] Open the last component page — only **Back** shows
- [x] Click through Back/Next and confirm URLs match sidebar order
- [x] Check mobile layout (stacked links) and desktop (side-by-side)

[Back and Next on Getting Started](https://cursor.com/agents/bc-2cf6692c-d59b-4348-883e-9fc29795cdcf/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdocs-pager-both.webp)
[Next only on Introduction](https://cursor.com/agents/bc-2cf6692c-d59b-4348-883e-9fc29795cdcf/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdocs-pager-next-only.webp)
[Back only on last page](https://cursor.com/agents/bc-2cf6692c-d59b-4348-883e-9fc29795cdcf/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdocs-pager-back-only.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2cf6692c-d59b-4348-883e-9fc29795cdcf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2cf6692c-d59b-4348-883e-9fc29795cdcf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

