### PR TITLE
fix: ASCII Fluid dark/light theme variants on toggle

### DIFF
--- a/registry/ascii-fluid/ascii-fluid-demo.tsx
+++ b/registry/ascii-fluid/ascii-fluid-demo.tsx
@@ -1,5 +1,8 @@
 "use client"
 
+import { useEffect, useMemo } from "react"
+import { useTheme } from "next-themes"
+
 import {
   ComponentControls,
   ControlColor,
@@ -10,19 +13,70 @@ import { ComponentPreview } from "@/components/component-preview"
 import { usePreviewProps } from "@/hooks/use-preview-props"
 import { AsciiFluid } from "@/registry/ascii-fluid/ascii-fluid"
 
-const DEFAULTS = {
-  cellSize: 12,
-  force: 1,
-  dissipation: 0.05,
-  brush: 0.55,
-  animate: true,
-  color: "#18181B",
-  backgroundColor: "#FAFAFA",
+/** Matches AsciiFluid theme defaults (uppercase for color inputs). */
+const LIGHT = { color: "#18181B", backgroundColor: "#FAFAFA" } as const
+const DARK = { color: "#E4E4E7", backgroundColor: "#09090B" } as const
+
+function norm(hex: string) {
+  return hex.trim().toUpperCase()
+}
+
+function matchesPalette(
+  color: string,
+  backgroundColor: string,
+  palette: { color: string; backgroundColor: string }
+) {
+  return (
+    norm(color) === norm(palette.color) &&
+    norm(backgroundColor) === norm(palette.backgroundColor)
+  )
+}
+
+/** True when ink/paper are still one of the built-in theme pairs. */
+function isStockThemePalette(color: string, backgroundColor: string) {
+  return (
+    matchesPalette(color, backgroundColor, LIGHT) ||
+    matchesPalette(color, backgroundColor, DARK)
+  )
 }
 
 export function AsciiFluidDemo() {
-  const { props, updateProp, resetProps, hasChanges } =
-    usePreviewProps(DEFAULTS)
+  const { resolvedTheme } = useTheme()
+  const palette = resolvedTheme === "dark" ? DARK : LIGHT
+
+  const defaults = useMemo(
+    () => ({
+      cellSize: 12,
+      force: 1,
+      dissipation: 0.05,
+      brush: 0.55,
+      animate: true,
+      color: palette.color,
+      backgroundColor: palette.backgroundColor,
+    }),
+    [palette]
+  )
+
+  const { props, updateProp, resetProps, hasChanges, setProps } =
+    usePreviewProps(defaults)
+
+  // Keep stock ink/paper on the active theme until the user picks custom colors.
+  useEffect(() => {
+    setProps((prev) => {
+      if (!isStockThemePalette(prev.color, prev.backgroundColor)) return prev
+      if (matchesPalette(prev.color, prev.backgroundColor, palette)) return prev
+      return {
+        ...prev,
+        color: palette.color,
+        backgroundColor: palette.backgroundColor,
+      }
+    })
+  }, [palette, setProps])
+
+  const useAutoTheme = isStockThemePalette(
+    props.color,
+    props.backgroundColor
+  )
 
   return (
     <>
@@ -38,8 +92,9 @@ export function AsciiFluidDemo() {
             dissipation={props.dissipation}
             brush={props.brush}
             animate={props.animate}
-            color={props.color}
-            backgroundColor={props.backgroundColor}
+            color={useAutoTheme ? undefined : props.color}
+            backgroundColor={useAutoTheme ? undefined : props.backgroundColor}
+            theme="auto"
           />
         </div>
       </ComponentPreview>

--- a/registry/ascii-fluid/ascii-fluid-demo.tsx
+++ b/registry/ascii-fluid/ascii-fluid-demo.tsx
@@ -14,8 +14,10 @@ import { usePreviewProps } from "@/hooks/use-preview-props"
 import { AsciiFluid } from "@/registry/ascii-fluid/ascii-fluid"
 
 /** Matches AsciiFluid theme defaults (uppercase for color inputs). */
-const LIGHT = { color: "#18181B", backgroundColor: "#FAFAFA" } as const
-const DARK = { color: "#E4E4E7", backgroundColor: "#09090B" } as const
+const LIGHT = { color: "#18181B", backgroundColor: "#FAFAFA" }
+const DARK = { color: "#E4E4E7", backgroundColor: "#09090B" }
+
+type ThemePalette = { color: string; backgroundColor: string }
 
 function norm(hex: string) {
   return hex.trim().toUpperCase()
@@ -24,7 +26,7 @@ function norm(hex: string) {
 function matchesPalette(
   color: string,
   backgroundColor: string,
-  palette: { color: string; backgroundColor: string }
+  palette: ThemePalette
 ) {
   return (
     norm(color) === norm(palette.color) &&
@@ -42,7 +44,7 @@ function isStockThemePalette(color: string, backgroundColor: string) {
 
 export function AsciiFluidDemo() {
   const { resolvedTheme } = useTheme()
-  const palette = resolvedTheme === "dark" ? DARK : LIGHT
+  const palette: ThemePalette = resolvedTheme === "dark" ? DARK : LIGHT
 
   const defaults = useMemo(
     () => ({
@@ -54,7 +56,7 @@ export function AsciiFluidDemo() {
       color: palette.color,
       backgroundColor: palette.backgroundColor,
     }),
-    [palette]
+    [palette.color, palette.backgroundColor]
   )
 
   const { props, updateProp, resetProps, hasChanges, setProps } =


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
The ASCII Fluid docs demo always passed hardcoded light ink/paper (`#18181B` / `#FAFAFA`), so pressing `d` toggled the page theme but the canvas stayed on the light variant.

## Changes
- Sync stock ink/paper with `next-themes` (`resolvedTheme`) so dark mode uses the dark palette and light mode uses the light palette.
- When colors are still a built-in theme pair, omit `color` / `backgroundColor` and keep `theme="auto"` so `AsciiFluid` follows the site theme.
- Custom color overrides from the props panel still win; Reset restores the active theme palette.
- Widen palette color types so the color picker `onChange` typechecks (fixes Vercel build failure).

## Test plan
- [ ] Open `/docs/components/ascii-fluid`
- [ ] Confirm light paper + dark ink in light mode
- [ ] Press `d` and confirm dark paper + light ink
- [ ] Press `d` again and confirm it returns to the light variant
- [ ] Customize ink/paper, toggle theme — custom colors should stick until Reset
- [ ] Vercel preview deploy succeeds
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fcb2b866-5051-4874-9461-1c2e1d4fe525?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fcb2b866-5051-4874-9461-1c2e1d4fe525&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

