### PR TITLE
Add draft site landing page at /landing

### DIFF
--- a/app/landing/landing-view.tsx
+++ b/app/landing/landing-view.tsx
@@ -103,8 +103,8 @@ export function LandingView() {
           </div>
         </section>
 
-        <section className="relative">
-          <div className="mx-auto max-w-5xl px-6 pb-6 text-center sm:px-10">
+        <section className="relative bg-background/80 backdrop-blur-sm">
+          <div className="mx-auto max-w-5xl px-6 py-16 text-center sm:px-10">
             <h2 className="text-xl font-medium tracking-tight text-foreground sm:text-2xl">
               Built to sit behind a real interface
             </h2>
@@ -113,19 +113,19 @@ export function LandingView() {
               ready to drop into your app.
             </p>
           </div>
-          <div className="w-full">
+          <div className="w-full overflow-hidden border-y border-border/60">
             <Image
               src="/demo-product.png"
               alt="Interface preview using 23rd backgrounds"
-              width={1600}
-              height={900}
+              width={1536}
+              height={1024}
               priority
-              className="h-auto w-full"
+              className="h-auto w-full object-cover object-top"
             />
           </div>
         </section>
 
-        <footer className="flex flex-col items-center gap-3 px-6 py-16 text-center sm:px-10">
+        <footer className="relative z-10 flex flex-col items-center gap-3 bg-background/90 px-6 py-16 text-center backdrop-blur-sm sm:px-10">
           <p className="font-[family-name:var(--font-landing-display)] text-3xl text-foreground">
             Ship with taste
           </p>

--- a/app/landing/landing-view.tsx
+++ b/app/landing/landing-view.tsx
@@ -1,0 +1,142 @@
+"use client"
+
+import Image from "next/image"
+import Link from "next/link"
+import { motion, useReducedMotion } from "motion/react"
+import { Instrument_Serif } from "next/font/google"
+
+import { Logo } from "@/components/logo"
+import { buttonVariants } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+import { ShaderGradient } from "@/registry/shader-gradient/shader-gradient"
+
+const display = Instrument_Serif({
+  subsets: ["latin"],
+  weight: "400",
+  variable: "--font-landing-display",
+})
+
+const ease = [0.22, 1, 0.36, 1] as const
+
+export function LandingView() {
+  const reduceMotion = useReducedMotion()
+
+  const initial = reduceMotion ? false : { opacity: 0, y: 18 }
+  const animate = { opacity: 1, y: 0 }
+
+  return (
+    <div className={cn(display.variable, "relative overflow-x-hidden")}>
+      <div className="pointer-events-none fixed inset-0 z-0">
+        <ShaderGradient className="absolute inset-0" />
+      </div>
+
+      <div className="relative z-10">
+        <header className="flex items-center justify-between px-6 py-5 sm:px-10">
+          <Link
+            href="/landing"
+            className="flex items-center gap-2.5 text-foreground"
+            aria-label="23rd home"
+          >
+            <Logo className="size-8" cornerRadius={8} />
+            <span className="text-sm font-medium tracking-tight">23rd</span>
+          </Link>
+          <Link
+            href="/docs"
+            className={cn(buttonVariants({ variant: "ghost", size: "sm" }))}
+          >
+            Docs
+          </Link>
+        </header>
+
+        <section className="flex min-h-[calc(100svh-4.5rem)] flex-col justify-center px-6 pb-16 pt-6 sm:px-10">
+          <div className="mx-auto w-full max-w-3xl text-center">
+            <motion.p
+              initial={initial}
+              animate={animate}
+              transition={{ duration: 0.7, ease }}
+              className="font-[family-name:var(--font-landing-display)] text-7xl leading-none tracking-tight text-foreground sm:text-8xl md:text-9xl"
+            >
+              23rd
+            </motion.p>
+
+            <motion.h1
+              initial={initial}
+              animate={animate}
+              transition={{ duration: 0.7, delay: reduceMotion ? 0 : 0.12, ease }}
+              className="mt-6 text-2xl font-medium tracking-tight text-foreground sm:text-3xl"
+            >
+              Opinionated components for shippers
+            </motion.h1>
+
+            <motion.p
+              initial={initial}
+              animate={animate}
+              transition={{ duration: 0.7, delay: reduceMotion ? 0 : 0.22, ease }}
+              className="mx-auto mt-4 max-w-md text-base leading-relaxed text-foreground/70 sm:text-lg"
+            >
+              Install from the registry, own the source, and start from a
+              sharper baseline.
+            </motion.p>
+
+            <motion.div
+              initial={initial}
+              animate={animate}
+              transition={{ duration: 0.7, delay: reduceMotion ? 0 : 0.32, ease }}
+              className="mt-8 flex flex-wrap items-center justify-center gap-3"
+            >
+              <Link
+                href="/docs"
+                className={cn(buttonVariants({ size: "lg" }), "min-w-36")}
+              >
+                Browse docs
+              </Link>
+              <Link
+                href="/demo"
+                className={cn(
+                  buttonVariants({ variant: "outline", size: "lg" }),
+                  "min-w-36 bg-background/60 backdrop-blur-sm"
+                )}
+              >
+                Live demo
+              </Link>
+            </motion.div>
+          </div>
+        </section>
+
+        <section className="relative">
+          <div className="mx-auto max-w-5xl px-6 pb-6 text-center sm:px-10">
+            <h2 className="text-xl font-medium tracking-tight text-foreground sm:text-2xl">
+              Built to sit behind a real interface
+            </h2>
+            <p className="mx-auto mt-2 max-w-md text-sm leading-relaxed text-foreground/65 sm:text-base">
+              Shader washes, fluid trails, and footers that feel finished —
+              ready to drop into your app.
+            </p>
+          </div>
+          <div className="w-full">
+            <Image
+              src="/demo-product.png"
+              alt="Interface preview using 23rd backgrounds"
+              width={1600}
+              height={900}
+              priority
+              className="h-auto w-full"
+            />
+          </div>
+        </section>
+
+        <footer className="flex flex-col items-center gap-3 px-6 py-16 text-center sm:px-10">
+          <p className="font-[family-name:var(--font-landing-display)] text-3xl text-foreground">
+            Ship with taste
+          </p>
+          <Link
+            href="/docs"
+            className={cn(buttonVariants({ size: "lg" }), "mt-2")}
+          >
+            Explore components
+          </Link>
+        </footer>
+      </div>
+    </div>
+  )
+}

--- a/app/landing/landing-view.tsx
+++ b/app/landing/landing-view.tsx
@@ -40,12 +40,17 @@ export function LandingView() {
             <Logo className="size-8" cornerRadius={8} />
             <span className="text-sm font-medium tracking-tight">23rd</span>
           </Link>
-          <Link
-            href="/docs"
-            className={cn(buttonVariants({ variant: "ghost", size: "sm" }))}
-          >
-            Docs
-          </Link>
+          <nav className="flex items-center gap-1">
+            <span className="mr-2 hidden text-xs text-muted-foreground sm:inline">
+              Draft
+            </span>
+            <Link
+              href="/docs"
+              className={cn(buttonVariants({ variant: "ghost", size: "sm" }))}
+            >
+              Docs
+            </Link>
+          </nav>
         </header>
 
         <section className="flex min-h-[calc(100svh-4.5rem)] flex-col justify-center px-6 pb-16 pt-6 sm:px-10">
@@ -62,7 +67,11 @@ export function LandingView() {
             <motion.h1
               initial={initial}
               animate={animate}
-              transition={{ duration: 0.7, delay: reduceMotion ? 0 : 0.12, ease }}
+              transition={{
+                duration: 0.7,
+                delay: reduceMotion ? 0 : 0.12,
+                ease,
+              }}
               className="mt-6 text-2xl font-medium tracking-tight text-foreground sm:text-3xl"
             >
               Opinionated components for shippers
@@ -71,33 +80,41 @@ export function LandingView() {
             <motion.p
               initial={initial}
               animate={animate}
-              transition={{ duration: 0.7, delay: reduceMotion ? 0 : 0.22, ease }}
+              transition={{
+                duration: 0.7,
+                delay: reduceMotion ? 0 : 0.22,
+                ease,
+              }}
               className="mx-auto mt-4 max-w-md text-base leading-relaxed text-foreground/70 sm:text-lg"
             >
-              Install from the registry, own the source, and start from a
-              sharper baseline.
+              A shadcn registry with strong defaults — install what you need,
+              own the source, and ship from a sharper baseline.
             </motion.p>
 
             <motion.div
               initial={initial}
               animate={animate}
-              transition={{ duration: 0.7, delay: reduceMotion ? 0 : 0.32, ease }}
+              transition={{
+                duration: 0.7,
+                delay: reduceMotion ? 0 : 0.32,
+                ease,
+              }}
               className="mt-8 flex flex-wrap items-center justify-center gap-3"
             >
               <Link
                 href="/docs"
                 className={cn(buttonVariants({ size: "lg" }), "min-w-36")}
               >
-                Browse docs
+                Read the docs
               </Link>
               <Link
-                href="/demo"
+                href="/docs/getting-started"
                 className={cn(
                   buttonVariants({ variant: "outline", size: "lg" }),
                   "min-w-36 bg-background/60 backdrop-blur-sm"
                 )}
               >
-                Live demo
+                Get started
               </Link>
             </motion.div>
           </div>
@@ -106,17 +123,17 @@ export function LandingView() {
         <section className="relative bg-background/80 backdrop-blur-sm">
           <div className="mx-auto max-w-5xl px-6 py-16 text-center sm:px-10">
             <h2 className="text-xl font-medium tracking-tight text-foreground sm:text-2xl">
-              Built to sit behind a real interface
+              Copy in. Ship out.
             </h2>
             <p className="mx-auto mt-2 max-w-md text-sm leading-relaxed text-foreground/65 sm:text-base">
-              Shader washes, fluid trails, and footers that feel finished —
-              ready to drop into your app.
+              Backgrounds, footers, and interaction pieces that already feel
+              finished — without a kitchen-sink design system.
             </p>
           </div>
           <div className="w-full overflow-hidden border-y border-border/60">
             <Image
               src="/demo-product.png"
-              alt="Interface preview using 23rd backgrounds"
+              alt="Interface preview using 23rd components"
               width={1536}
               height={1024}
               priority
@@ -129,11 +146,14 @@ export function LandingView() {
           <p className="font-[family-name:var(--font-landing-display)] text-3xl text-foreground">
             Ship with taste
           </p>
+          <p className="max-w-sm text-sm text-muted-foreground">
+            Draft homepage preview — production still opens on docs.
+          </p>
           <Link
             href="/docs"
-            className={cn(buttonVariants({ size: "lg" }), "mt-2")}
+            className={cn(buttonVariants({ size: "lg" }), "mt-1")}
           >
-            Explore components
+            Browse components
           </Link>
         </footer>
       </div>

--- a/app/landing/page.tsx
+++ b/app/landing/page.tsx
@@ -3,9 +3,13 @@ import type { Metadata } from "next"
 import { LandingView } from "./landing-view"
 
 export const metadata: Metadata = {
-  title: "Landing",
+  title: "23rd",
   description:
-    "23rd — opinionated UI components for shippers. A demo landing page with live shader backgrounds.",
+    "Opinionated UI components for shippers — a shadcn registry. Draft site landing (not the production homepage).",
+  robots: {
+    index: false,
+    follow: false,
+  },
 }
 
 export default function LandingPage() {

--- a/app/landing/page.tsx
+++ b/app/landing/page.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next"
+
+import { LandingView } from "./landing-view"
+
+export const metadata: Metadata = {
+  title: "Landing",
+  description:
+    "23rd — opinionated UI components for shippers. A demo landing page with live shader backgrounds.",
+}
+
+export default function LandingPage() {
+  return <LandingView />
+}

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -5,6 +5,8 @@ export default function robots(): MetadataRoute.Robots {
     rules: {
       userAgent: "*",
       allow: "/",
+      // Draft site landing — not the production homepage yet
+      disallow: ["/landing"],
     },
     sitemap: "https://23rd.dev/sitemap.xml",
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a **draft** homepage for 23rd at `/landing`. Production is unchanged.

### Production stays as-is
- `/` still redirects to `/docs`
- `/landing` is **not** in the sitemap
- `robots` disallows `/landing` and the page is `noindex`

### Draft landing (`/landing`)
- Branded hero for the 23rd site with live shader background
- CTAs into docs / getting started
- Product preview + closing CTA
- Small “Draft” label so it’s obvious this isn’t live homepage yet

### Preview
Visit `/landing` locally. Root (`/`) continues to open docs.

[Landing hero desktop](https://cursor.com/agents/bc-0b4b882e-20cf-46ce-ad55-e28c6924ce64/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Flanding-hero-desktop.webp)
[Landing preview and footer](https://cursor.com/agents/bc-0b4b882e-20cf-46ce-ad55-e28c6924ce64/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Flanding-preview-footer.webp)
[Landing hero mobile](https://cursor.com/agents/bc-0b4b882e-20cf-46ce-ad55-e28c6924ce64/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Flanding-hero-mobile.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0b4b882e-20cf-46ce-ad55-e28c6924ce64?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b4b882e-20cf-46ce-ad55-e28c6924ce64&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

