### PR TITLE
feat: add full-site SEO metadata, OG cards, and structured data

### DIFF
--- a/app/docs/[[...slug]]/opengraph-image.tsx
+++ b/app/docs/[[...slug]]/opengraph-image.tsx
@@ -1,0 +1,124 @@
+import { ImageResponse } from "next/og"
+import { readFile } from "node:fs/promises"
+import { join } from "node:path"
+
+import { SITE_NAME, SITE_TAGLINE } from "@/lib/seo"
+import { source } from "@/lib/source"
+
+export const alt = "23rd documentation"
+export const size = {
+  width: 1200,
+  height: 630,
+}
+export const contentType = "image/png"
+
+export function generateStaticParams() {
+  return source.generateParams()
+}
+
+export default async function Image({
+  params,
+}: {
+  params: Promise<{ slug?: string[] }>
+}) {
+  const { slug } = await params
+  const page = source.getPage(slug)
+  const isIndex = !slug?.length
+  const title = isIndex ? SITE_NAME : (page?.data.title ?? SITE_NAME)
+  const description = isIndex
+    ? SITE_TAGLINE
+    : (page?.data.description ?? SITE_TAGLINE)
+
+  const logo = await readFile(join(process.cwd(), "app/apple-icon.png"))
+  const logoSrc = `data:image/png;base64,${logo.toString("base64")}`
+
+  return new ImageResponse(
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "space-between",
+        background: "#0a0a0a",
+        color: "#fafafa",
+        padding: 72,
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center" }}>
+          {/* ImageResponse only supports <img>, not next/image */}
+          {/* eslint-disable-next-line @next/next/no-img-element -- ImageResponse */}
+          <img
+            src={logoSrc}
+            width={56}
+            height={56}
+            alt=""
+            style={{ borderRadius: 8 }}
+          />
+          <div
+            style={{
+              display: "flex",
+              marginLeft: 16,
+              fontSize: 28,
+              fontWeight: 600,
+              letterSpacing: "-0.04em",
+            }}
+          >
+            {SITE_NAME}
+          </div>
+        </div>
+        <div
+          style={{
+            display: "flex",
+            fontSize: 22,
+            color: "#737373",
+          }}
+        >
+          23rd.dev
+        </div>
+      </div>
+      <div style={{ display: "flex", flexDirection: "column" }}>
+        <div
+          style={{
+            display: "flex",
+            fontSize: title.length > 28 ? 56 : 64,
+            fontWeight: 600,
+            letterSpacing: "-0.04em",
+            lineHeight: 1.1,
+          }}
+        >
+          {title}
+        </div>
+        <div
+          style={{
+            display: "flex",
+            marginTop: 20,
+            fontSize: 26,
+            color: "#a3a3a3",
+            lineHeight: 1.35,
+            maxWidth: 980,
+          }}
+        >
+          {description}
+        </div>
+      </div>
+      <div
+        style={{
+          display: "flex",
+          fontSize: 20,
+          color: "#737373",
+        }}
+      >
+        shadcn registry
+      </div>
+    </div>,
+    { ...size }
+  )
+}

--- a/app/docs/[[...slug]]/page.tsx
+++ b/app/docs/[[...slug]]/page.tsx
@@ -4,7 +4,16 @@ import { notFound } from "next/navigation"
 
 import { DocsPager } from "@/components/docs-pager"
 import { DocsToc } from "@/components/docs-toc"
+import { JsonLd } from "@/components/json-ld"
 import { getMDXComponents } from "@/components/mdx"
+import {
+  buildPageMetadata,
+  docsJsonLd,
+  docsPath,
+  isComponentPage,
+  isDocsIndex,
+  SITE_TITLE,
+} from "@/lib/seo"
 import { source } from "@/lib/source"
 
 export default async function Page(props: {
@@ -24,6 +33,14 @@ export default async function Page(props: {
       {...(isStretchyFooter ? { "data-stretchy-page": "" } : {})}
     >
       <article className="mx-auto w-full max-w-2xl">
+        <JsonLd
+          data={docsJsonLd({
+            title: page.data.title,
+            description: page.data.description,
+            path: docsPath(params.slug),
+            slug: params.slug,
+          })}
+        />
         <h1 className="text-3xl font-semibold tracking-tight">
           {page.data.title}
         </h1>
@@ -57,8 +74,17 @@ export async function generateMetadata(props: {
   const page = source.getPage(params.slug)
   if (!page) notFound()
 
-  return {
-    title: page.data.title,
+  const path = docsPath(params.slug)
+  const extraKeywords = isComponentPage(params.slug)
+    ? [page.data.title, "shadcn component", "React component"]
+    : [page.data.title]
+
+  return buildPageMetadata({
+    title: isDocsIndex(params.slug) ? SITE_TITLE : page.data.title,
     description: page.data.description,
-  }
+    path,
+    keywords: extraKeywords,
+    type: "article",
+    absoluteTitle: isDocsIndex(params.slug),
+  })
 }

--- a/app/icon.svg
+++ b/app/icon.svg
@@ -1,0 +1,6 @@
+<svg width="200" height="200" viewBox="0 0 200 200" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="200" height="200" rx="11" fill="white"/>
+  <path d="M21.5 30H163.5L21.5 128.5L177.5 96.5V136.5V186H21.5" stroke="black" stroke-width="8"/>
+  <path d="M70 7H90V192H70V7Z" fill="black"/>
+  <path d="M110 7H130V192H110V7Z" fill="black"/>
+</svg>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,13 +1,23 @@
 import { Geist, Geist_Mono } from "next/font/google"
 import { RootProvider } from "fumadocs-ui/provider/next"
-import type { Metadata } from "next"
+import type { Metadata, Viewport } from "next"
 import Script from "next/script"
 import type { ReactNode } from "react"
 
 import { DocsSearchDialog } from "@/components/docs-search-dialog"
+import { JsonLd } from "@/components/json-ld"
 import { ThemeProvider } from "@/components/theme-provider"
 import { TooltipProvider } from "@/components/ui/tooltip"
 import { Toaster } from "sonner"
+import {
+  SITE_AUTHOR,
+  SITE_DESCRIPTION,
+  SITE_KEYWORDS,
+  SITE_NAME,
+  SITE_TITLE,
+  SITE_URL,
+  rootJsonLd,
+} from "@/lib/seo"
 import { cn } from "@/lib/utils"
 import { source } from "@/lib/source"
 import { flattenPageTree } from "@/lib/tree"
@@ -15,13 +25,66 @@ import { flattenPageTree } from "@/lib/tree"
 import "./globals.css"
 
 export const metadata: Metadata = {
+  metadataBase: new URL(SITE_URL),
   title: {
-    default: "23rd Docs",
-    template: "%s · 23rd",
+    default: SITE_TITLE,
+    template: `%s · ${SITE_NAME}`,
   },
-  description:
-    "Opinionated components for shippers — documentation and registry built with Fumadocs MDX and Next.js.",
-  metadataBase: new URL("https://23rd.dev"),
+  description: SITE_DESCRIPTION,
+  applicationName: SITE_NAME,
+  keywords: SITE_KEYWORDS,
+  authors: [SITE_AUTHOR],
+  creator: SITE_AUTHOR.name,
+  publisher: SITE_NAME,
+  category: "technology",
+  formatDetection: {
+    email: false,
+    address: false,
+    telephone: false,
+  },
+  alternates: {
+    canonical: "/docs",
+    types: {
+      "text/plain": "/llms.txt",
+    },
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      "max-image-preview": "large",
+      "max-snippet": -1,
+      "max-video-preview": -1,
+    },
+  },
+  openGraph: {
+    type: "website",
+    locale: "en_US",
+    url: "/docs",
+    siteName: SITE_NAME,
+    title: SITE_TITLE,
+    description: SITE_DESCRIPTION,
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: SITE_TITLE,
+    description: SITE_DESCRIPTION,
+  },
+  appleWebApp: {
+    title: SITE_NAME,
+    capable: true,
+    statusBarStyle: "black-translucent",
+  },
+}
+
+export const viewport: Viewport = {
+  themeColor: [
+    { media: "(prefers-color-scheme: light)", color: "#ffffff" },
+    { media: "(prefers-color-scheme: dark)", color: "#0a0a0a" },
+  ],
+  colorScheme: "light dark",
 }
 
 const geist = Geist({ subsets: ["latin"], variable: "--font-sans" })
@@ -44,13 +107,10 @@ export default function RootLayout({
     <html
       lang="en"
       suppressHydrationWarning
-      className={cn(
-        "font-sans antialiased",
-        fontMono.variable,
-        geist.variable
-      )}
+      className={cn("font-sans antialiased", fontMono.variable, geist.variable)}
     >
       <body className="flex min-h-screen flex-col">
+        <JsonLd data={rootJsonLd()} />
         <ThemeProvider>
           <RootProvider
             search={{

--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -1,0 +1,71 @@
+import { source } from "@/lib/source"
+import { getGithubRepoUrl } from "@/lib/github"
+import {
+  SITE_DESCRIPTION,
+  SITE_NAME,
+  SITE_TAGLINE,
+  SITE_URL,
+  absoluteUrl,
+  docsPath,
+} from "@/lib/seo"
+
+export const dynamic = "force-static"
+
+export function GET() {
+  const pages = source.generateParams().map((param) => {
+    const page = source.getPage(param.slug)
+    if (!page) return null
+    return {
+      title: page.data.title,
+      description: page.data.description,
+      url: absoluteUrl(page.url || docsPath(param.slug)),
+      slug: param.slug ?? [],
+    }
+  })
+
+  const docs = pages.filter(
+    (page): page is NonNullable<(typeof pages)[number]> => page != null
+  )
+  const components = docs.filter((page) => page.slug[0] === "components")
+  const guides = docs.filter((page) => page.slug[0] !== "components")
+
+  const list = (items: typeof docs) =>
+    items
+      .map((page) => {
+        const desc = page.description ? `: ${page.description}` : ""
+        return `- [${page.title}](${page.url})${desc}`
+      })
+      .join("\n")
+
+  const body = `# ${SITE_NAME}
+
+> ${SITE_TAGLINE}
+
+${SITE_DESCRIPTION}
+
+Site: ${SITE_URL}
+Docs: ${absoluteUrl("/docs")}
+Registry: ${absoluteUrl("/r/registry.json")}
+GitHub: ${getGithubRepoUrl()}
+
+## Docs
+
+${list(guides)}
+
+## Components
+
+${list(components)}
+
+## Optional
+
+- [Full documentation](${absoluteUrl("/docs")})
+- [Install with shadcn CLI](${absoluteUrl("/docs/getting-started")})
+`
+
+  return new Response(body, {
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+      "Cache-Control": "public, max-age=3600",
+    },
+  })
+}

--- a/app/manifest.ts
+++ b/app/manifest.ts
@@ -1,0 +1,29 @@
+import type { MetadataRoute } from "next"
+
+import { SITE_DESCRIPTION, SITE_NAME, SITE_TAGLINE } from "@/lib/seo"
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: `${SITE_NAME} — ${SITE_TAGLINE}`,
+    short_name: SITE_NAME,
+    description: SITE_DESCRIPTION,
+    start_url: "/docs",
+    display: "standalone",
+    background_color: "#000000",
+    theme_color: "#000000",
+    icons: [
+      {
+        src: "/icon.svg",
+        sizes: "any",
+        type: "image/svg+xml",
+        purpose: "any",
+      },
+      {
+        src: "/apple-icon.png",
+        sizes: "180x180",
+        type: "image/png",
+        purpose: "any",
+      },
+    ],
+  }
+}

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,7 +1,18 @@
+import type { Metadata } from "next"
 import Link from "next/link"
 
 import { buttonVariants } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
+
+export const metadata: Metadata = {
+  title: "Page not found",
+  description:
+    "This page could not be found. It might have been moved or deleted.",
+  robots: {
+    index: false,
+    follow: false,
+  },
+}
 
 export default function NotFound() {
   return (
@@ -11,7 +22,10 @@ export default function NotFound() {
         <p className="text-muted-foreground">
           This page could not be found. It might have been moved or deleted.
         </p>
-        <Link href="/docs" className={cn(buttonVariants({ variant: "default" }))}>
+        <Link
+          href="/docs"
+          className={cn(buttonVariants({ variant: "default" }))}
+        >
           Back to docs
         </Link>
       </div>

--- a/app/opengraph-image.alt.txt
+++ b/app/opengraph-image.alt.txt
@@ -1,0 +1,1 @@
+23rd — Opinionated UI components for shippers

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,11 +1,17 @@
 import type { MetadataRoute } from "next"
 
+import { SITE_URL } from "@/lib/seo"
+
 export default function robots(): MetadataRoute.Robots {
   return {
-    rules: {
-      userAgent: "*",
-      allow: "/",
-    },
-    sitemap: "https://23rd.dev/sitemap.xml",
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: ["/api/"],
+      },
+    ],
+    sitemap: `${SITE_URL}/sitemap.xml`,
+    host: SITE_URL,
   }
 }

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,26 +1,33 @@
 import type { MetadataRoute } from "next"
 
+import { absoluteUrl, docsPath } from "@/lib/seo"
 import { source } from "@/lib/source"
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const params = source.generateParams()
+  const seen = new Set<string>()
+  const entries: MetadataRoute.Sitemap = []
 
-  return [
-    {
-      url: "https://23rd.dev/docs",
-      lastModified: new Date(),
-      changeFrequency: "weekly",
-      priority: 1,
-    },
-    ...params.map((param) => {
-      const slug = param.slug?.join("/") ?? ""
-      if (!slug) return null
-      return {
-        url: `https://23rd.dev/docs/${slug}`,
-        lastModified: new Date(),
-        changeFrequency: "weekly" as const,
-        priority: 0.6,
-      }
-    }).filter((entry): entry is NonNullable<typeof entry> => entry != null),
-  ]
+  const add = (
+    path: string,
+    priority: number,
+    changeFrequency: MetadataRoute.Sitemap[number]["changeFrequency"] = "weekly"
+  ) => {
+    const url = absoluteUrl(path)
+    if (seen.has(url)) return
+    seen.add(url)
+    entries.push({ url, changeFrequency, priority })
+  }
+
+  add("/docs", 1)
+
+  for (const param of source.generateParams()) {
+    const page = source.getPage(param.slug)
+    const path = page?.url || docsPath(param.slug)
+    const isIndex = !param.slug?.length
+    const isComponent = param.slug?.[0] === "components"
+
+    add(path, isIndex ? 1 : isComponent ? 0.8 : 0.7)
+  }
+
+  return entries
 }

--- a/components/json-ld.tsx
+++ b/components/json-ld.tsx
@@ -1,0 +1,10 @@
+export function JsonLd({ data }: { data: unknown }) {
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{
+        __html: JSON.stringify(data).replace(/</g, "\\u003c"),
+      }}
+    />
+  )
+}

--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -1,0 +1,219 @@
+import type { Metadata } from "next"
+
+import { getGithubRepoUrl } from "@/lib/github"
+
+export const SITE_URL = "https://23rd.dev"
+export const SITE_NAME = "23rd"
+export const SITE_TAGLINE = "Opinionated UI components for shippers"
+export const SITE_TITLE = `${SITE_NAME} — ${SITE_TAGLINE}`
+export const SITE_DESCRIPTION =
+  "A shadcn/ui registry of opinionated React components — shaders, backgrounds, footers, and interactive UI. Install with the CLI, own the source, and ship."
+
+export const SITE_KEYWORDS = [
+  "23rd",
+  "shadcn",
+  "shadcn registry",
+  "shadcn/ui",
+  "React components",
+  "UI components",
+  "Next.js",
+  "Tailwind CSS",
+  "WebGL",
+  "shaders",
+  "Motion",
+  "open source",
+]
+
+export const SITE_AUTHOR = {
+  name: "radiumcoders (Jay)",
+  url: "https://github.com/radiumcoders",
+}
+
+export function absoluteUrl(path = "/"): string {
+  if (path.startsWith("http://") || path.startsWith("https://")) return path
+  const normalized = path.startsWith("/") ? path : `/${path}`
+  return new URL(normalized, SITE_URL).toString()
+}
+
+export function docsPath(slug?: string[]): string {
+  if (!slug?.length) return "/docs"
+  return `/docs/${slug.join("/")}`
+}
+
+export function isDocsIndex(slug?: string[]): boolean {
+  return !slug?.length
+}
+
+export function isComponentPage(slug?: string[]): boolean {
+  return slug?.[0] === "components" && (slug?.length ?? 0) > 1
+}
+
+export function buildPageMetadata({
+  title,
+  description,
+  path,
+  keywords = [],
+  type = "website",
+  absoluteTitle = false,
+}: {
+  title: string
+  description?: string
+  path: string
+  keywords?: string[]
+  type?: "website" | "article"
+  absoluteTitle?: boolean
+}): Metadata {
+  const desc = description?.trim() || SITE_DESCRIPTION
+  const ogTitle = absoluteTitle ? title : `${title} · ${SITE_NAME}`
+
+  return {
+    title: absoluteTitle ? { absolute: title } : title,
+    description: desc,
+    keywords: [...SITE_KEYWORDS, ...keywords],
+    authors: [SITE_AUTHOR],
+    alternates: {
+      canonical: path,
+    },
+    openGraph: {
+      title: ogTitle,
+      description: desc,
+      url: path,
+      siteName: SITE_NAME,
+      locale: "en_US",
+      type,
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: ogTitle,
+      description: desc,
+    },
+  }
+}
+
+export function organizationJsonLd() {
+  return {
+    "@type": "Organization",
+    "@id": `${SITE_URL}/#organization`,
+    name: SITE_NAME,
+    url: SITE_URL,
+    logo: {
+      "@type": "ImageObject",
+      url: absoluteUrl("/logo.svg"),
+    },
+    sameAs: [getGithubRepoUrl(), "https://github.com/radiumcoders"],
+  }
+}
+
+export function websiteJsonLd() {
+  return {
+    "@type": "WebSite",
+    "@id": `${SITE_URL}/#website`,
+    name: SITE_NAME,
+    url: SITE_URL,
+    description: SITE_DESCRIPTION,
+    inLanguage: "en",
+    publisher: { "@id": `${SITE_URL}/#organization` },
+  }
+}
+
+export function softwareJsonLd() {
+  return {
+    "@type": "SoftwareApplication",
+    "@id": `${SITE_URL}/#app`,
+    name: SITE_NAME,
+    applicationCategory: "DeveloperApplication",
+    operatingSystem: "Web",
+    offers: {
+      "@type": "Offer",
+      price: "0",
+      priceCurrency: "USD",
+    },
+    url: absoluteUrl("/docs"),
+    description: SITE_DESCRIPTION,
+    author: {
+      "@type": "Person",
+      name: SITE_AUTHOR.name,
+      url: SITE_AUTHOR.url,
+    },
+    publisher: { "@id": `${SITE_URL}/#organization` },
+  }
+}
+
+export function rootJsonLd() {
+  return {
+    "@context": "https://schema.org",
+    "@graph": [organizationJsonLd(), websiteJsonLd(), softwareJsonLd()],
+  }
+}
+
+export function docsJsonLd({
+  title,
+  description,
+  path,
+  slug,
+}: {
+  title: string
+  description?: string
+  path: string
+  slug?: string[]
+}) {
+  const url = absoluteUrl(path)
+  const desc = description?.trim() || SITE_DESCRIPTION
+  const breadcrumbs = docsBreadcrumbs(slug, title)
+  const graph: Record<string, unknown>[] = [
+    {
+      "@type": "TechArticle",
+      headline: title,
+      name: title,
+      description: desc,
+      url,
+      inLanguage: "en",
+      isPartOf: { "@id": `${SITE_URL}/#website` },
+      author: {
+        "@type": "Person",
+        name: SITE_AUTHOR.name,
+        url: SITE_AUTHOR.url,
+      },
+      publisher: { "@id": `${SITE_URL}/#organization` },
+      mainEntityOfPage: url,
+    },
+    {
+      "@type": "BreadcrumbList",
+      itemListElement: breadcrumbs.map((crumb, index) => ({
+        "@type": "ListItem",
+        position: index + 1,
+        name: crumb.name,
+        item: absoluteUrl(crumb.path),
+      })),
+    },
+  ]
+
+  if (isComponentPage(slug)) {
+    graph.push({
+      "@type": "SoftwareSourceCode",
+      name: title,
+      description: desc,
+      url,
+      codeRepository: getGithubRepoUrl(),
+      programmingLanguage: ["TypeScript", "React"],
+      runtimePlatform: "React",
+      isPartOf: { "@id": `${SITE_URL}/#app` },
+    })
+  }
+
+  return {
+    "@context": "https://schema.org",
+    "@graph": graph,
+  }
+}
+
+function docsBreadcrumbs(slug: string[] | undefined, title: string) {
+  const crumbs: { name: string; path: string }[] = [
+    { name: SITE_NAME, path: "/docs" },
+  ]
+
+  if (isDocsIndex(slug)) return crumbs
+
+  crumbs.push({ name: title, path: docsPath(slug) })
+  return crumbs
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -14,7 +14,7 @@ const config = {
       {
         source: "/",
         destination: "/docs",
-        permanent: false,
+        permanent: true,
       },
     ]
   },


### PR DESCRIPTION
Give docs pages canonical URLs, JSON-LD, and per-page social images so search and shares pick up 23rd correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added branded Open Graph images for documentation pages.
  * Added structured metadata and JSON-LD for the site and documentation.
  * Added a generated plain-text documentation index for AI tools.
  * Added web app manifest, icons, and enhanced sharing metadata.
  * Added sitemap entries for documentation pages.

* **Bug Fixes**
  * Improved robots directives and sitemap configuration.
  * Made the root redirect to documentation permanent.
  * Prevented not-found pages from being indexed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->