### PR TITLE
Deploy Cloudflare preview URLs for pull requests

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -39,10 +39,7 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
   preview:
-    if: >
-      github.event_name == 'pull_request' &&
-      github.event.pull_request.head.repo.full_name == github.repository &&
-      secrets.CLOUDFLARE_API_TOKEN != ''
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -3,10 +3,16 @@ name: Deploy to Cloudflare Workers
 on:
   push:
     branches: [main]
+  pull_request:
   workflow_dispatch:
+
+concurrency:
+  group: cloudflare-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   deploy:
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -31,3 +37,156 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+  preview:
+    if: >
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      secrets.CLOUDFLARE_API_TOKEN != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 11.20.0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build OpenNext Worker
+        run: pnpm exec opennextjs-cloudflare build
+
+      - name: Upload preview version
+        id: upload
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          WRANGLER_OUTPUT_FILE_DIRECTORY: ${{ runner.temp }}/wrangler-output
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          mkdir -p "$WRANGLER_OUTPUT_FILE_DIRECTORY"
+          alias="pr-${PR_NUMBER}"
+          # Do not put spaces or '#' in wrangler flags: OpenNext runs wrangler with shell: true.
+          pnpm exec opennextjs-cloudflare upload --preview-alias "$alias"
+
+          node <<'NODE'
+          const fs = require("node:fs")
+          const path = require("node:path")
+          const dir = process.env.WRANGLER_OUTPUT_FILE_DIRECTORY
+          let previewUrl = ""
+          let aliasUrl = ""
+          for (const name of fs.readdirSync(dir)) {
+            const text = fs.readFileSync(path.join(dir, name), "utf8")
+            for (const line of text.split("\n")) {
+              if (!line.trim()) continue
+              try {
+                const entry = JSON.parse(line)
+                if (entry.type === "version-upload") {
+                  previewUrl = entry.preview_url || previewUrl
+                  aliasUrl = entry.preview_alias_url || aliasUrl
+                }
+              } catch {
+                // ignore non-JSON lines
+              }
+            }
+          }
+          const githubOutput = process.env.GITHUB_OUTPUT
+          if (!githubOutput) {
+            throw new Error("GITHUB_OUTPUT is not set")
+          }
+          fs.appendFileSync(githubOutput, `preview_url=${previewUrl}\n`)
+          fs.appendFileSync(githubOutput, `alias_url=${aliasUrl}\n`)
+          if (!previewUrl && !aliasUrl) {
+            console.warn(
+              "Wrangler did not report a preview URL. Confirm preview_urls is enabled on the Worker."
+            )
+          }
+          NODE
+
+      - name: Comment preview URL on the PR
+        if: steps.upload.outputs.alias_url != '' || steps.upload.outputs.preview_url != ''
+        uses: actions/github-script@v7
+        env:
+          ALIAS_URL: ${{ steps.upload.outputs.alias_url }}
+          PREVIEW_URL: ${{ steps.upload.outputs.preview_url }}
+        with:
+          script: |
+            const marker = "<!-- cloudflare-preview -->"
+            const aliasUrl = process.env.ALIAS_URL
+            const previewUrl = process.env.PREVIEW_URL
+            const url = aliasUrl || previewUrl
+            const rows = [
+              "| | |",
+              "| --- | --- |",
+              `| Preview | ${url} |`,
+            ]
+            if (previewUrl && previewUrl !== url) {
+              rows.push(`| This commit | ${previewUrl} |`)
+            }
+            const body = [
+              marker,
+              "**Cloudflare preview** is ready.",
+              "",
+              ...rows,
+              "",
+              "Production ([23rd.dev](https://23rd.dev)) is unchanged. This preview URL stays the same as you push to this PR.",
+            ].join("\n")
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            })
+            const existing = comments.find((comment) => comment.body?.includes(marker))
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              })
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              })
+            }
+
+            try {
+              const { data: deployment } = await github.rest.repos.createDeployment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: context.payload.pull_request.head.sha,
+                environment: "preview",
+                auto_merge: false,
+                required_contexts: [],
+                description: `PR #${context.issue.number} Cloudflare preview`,
+                transient_environment: true,
+                production_environment: false,
+              })
+              if (deployment && deployment.id) {
+                await github.rest.repos.createDeploymentStatus({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  deployment_id: deployment.id,
+                  state: "success",
+                  environment_url: url,
+                  log_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+                  description: "Cloudflare Workers preview",
+                })
+              }
+            } catch (error) {
+              core.warning(`Could not create GitHub deployment: ${error.message}`)
+            }

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Useful scripts:
 | `pnpm build`          | Build registry + production app                        |
 | `pnpm preview`        | Build with OpenNext and preview in the Workers runtime |
 | `pnpm cf:deploy`      | Build with OpenNext and deploy to Cloudflare Workers   |
+| `pnpm cf:upload`      | Build with OpenNext and upload a preview version       |
 | `pnpm registry:build` | Emit `public/r/*.json` from `registry/`                |
 | `pnpm test`           | Run registry tests                                     |
 | `pnpm typecheck`      | MDX + TypeScript check                                 |
@@ -138,7 +139,15 @@ Stack: Next.js 16, React 19, Fumadocs, Tailwind CSS 4, shadcn/ui (Base UI), Clou
 pnpm cf:deploy
 ```
 
-Connect the repo in the [Cloudflare dashboard](https://dash.cloudflare.com/) (Workers Builds) for Git-based deploys. Point `23rd.dev` DNS at the Worker when you're ready to cut over from Vercel.
+GitHub Actions deploys production on push to `main`. Opening a PR uploads a **preview version** (production is untouched) and comments a stable URL, the same idea as Vercel preview deployments:
+
+`https://pr-<number>-23rd-dev.<subdomain>.workers.dev`
+
+That alias stays put as you push more commits to the same PR. Preview URLs live on `workers.dev`; they are public unless you later put [Cloudflare Access](https://developers.cloudflare.com/workers/configuration/cloudflare-access/) in front of them.
+
+You can get the same PR comments from [Workers Builds](https://developers.cloudflare.com/workers/ci-cd/builds/) instead: connect the repo in the [Cloudflare dashboard](https://dash.cloudflare.com/), set the deploy command to `pnpm cf:deploy`, the non-production command to `pnpm cf:upload`, and enable **Builds for non-production branches**. Don’t run both Workers Builds and this GitHub Action for the same events or you’ll double-deploy.
+
+Point `23rd.dev` DNS at the Worker when you’re ready to cut over from Vercel.
 
 ## Contributing
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -4,6 +4,7 @@
   "main": ".open-next/worker.js",
   "compatibility_date": "2026-08-06",
   "compatibility_flags": ["nodejs_compat", "global_fetch_strictly_public"],
+  "preview_urls": true,
   "assets": {
     "directory": ".open-next/assets",
     "binding": "ASSETS",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Yes — Cloudflare can do the Vercel-style thing: each PR gets a shareable preview URL that does not touch production.

This wires it into the existing GitHub Action (Workers already deploy from Actions on `main`). It already ran on this PR:

- Preview: https://pr-21-23rd-dev.radiumcoders.workers.dev
- This commit: https://1e161500-23rd-dev.radiumcoders.workers.dev

## What you get

Opening or updating a PR:

1. Builds the OpenNext Worker
2. Uploads a **version** with `opennextjs-cloudflare upload` (not `deploy`, so [23rd.dev](https://23rd.dev) stays on the current production deployment)
3. Comments a stable preview URL:
   `https://pr-<number>-23rd-dev.radiumcoders.workers.dev`
4. Also posts a GitHub `preview` deployment so the PR shows a View deployment button

That alias stays the same as you push more commits. Each commit also gets a versioned `workers.dev` URL.

## Repo changes

- `wrangler.jsonc`: `preview_urls: true` so preview hostnames are actually served
- `.github/workflows/deploy-cloudflare.yml`: `pull_request` job using `--preview-alias pr-<number>`
- README notes the Vercel-like flow, and the Workers Builds dashboard alternative (do not run both for the same events)

Fork PRs are skipped (no deploy secrets). Preview URLs are public on `*.workers.dev`. Put [Cloudflare Access](https://developers.cloudflare.com/workers/configuration/cloudflare-access/) in front if you want them signed-in only.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f83504ad-cc7d-46ce-be33-0b8417950ca7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f83504ad-cc7d-46ce-be33-0b8417950ca7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic preview deployments for pull requests.
  * Preview URLs are posted to pull request conversations and support stable PR-specific links.
  * Added manual deployment workflow support.

* **Documentation**
  * Expanded Cloudflare deployment guidance, including production releases, previews, DNS setup, and local upload commands.

* **Enhancements**
  * Enabled preview URLs for Cloudflare deployments.
  * Production deployments are skipped for pull-request events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->